### PR TITLE
Make -r RegExp Windows compatible

### DIFF
--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `/node_modules\/(?!(${dependencies.join('|')}))/`
+  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')}))`
 }


### PR DESCRIPTION
This also removes the trailing slash from the path, I don't know exactly why but that made it fail in my repo.