### PR TITLE
🐛 Restore pre 1.2.1 RegExp format, make fully Win compat + less greedy

### DIFF
--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `/[\\/]node_modules[\\/](?!(${dependencies.join('|')})[\\/])/`
+  return `/[\\\\/]node_modules[\\\\/](?!(${dependencies.join('|')})[\\\\/])/`;
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')}))[\\/]`
+  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')})[\\/])`
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `/[\\\\/]node_modules[\\\\/](?!(${dependencies.join('|')})[\\\\/])/`;
+  return `/[\\\\/]node_modules[\\\\/](?!(${dependencies.join('|')})[\\\\/])/`
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')})[\\/])`
+  return `/[\\/]node_modules[\\/](?!(${dependencies.join('|')})[\\/])/`
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,3 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
-  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')}))`
+  return `[\\/]node_modules[\\/](?!(${dependencies.join('|')}))[\\/]`
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,3 +1,10 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
+  // [\\\\/] is a bit confusing but what it's doing is matching either a
+  // backslash or forwards slash. Forwards slashes don't need to be
+  // escaped inside a character group, and we need to escape the
+  // backslash twice because we're in a string, and in a regex.
+  //
+  // If you console.log the regex it'll actually turn into:
+  // [\\/]
   return `/[\\\\/]node_modules[\\\\/](?!(${dependencies.join('|')})[\\\\/])/`
 }


### PR DESCRIPTION
Sorry for the confusion :cry: 

There were a few things going wrong here:

When looking at `/node_modules\/(?!(deps|go|here))/` (as of d4d4985bc288e1abc995b7a04046d41efba8038), I thought the surrounding slashes were meant as path delimiters (obviously not matching on Windows systems). But I was wrong - those are the RegExp delimiters (the slash in the middle however _is_ a path delimiter).

What that also means is that `src/traverse_node_modules/walker.js` will match and as such be excluded from transpilation (however, on a Windows machine, `src\traverse_node_modules\walker.js` won't), just as `/node_modules/p-debounce-es5/index.es5.js` _will_ be transpiled if the matched deps include `p-debounce`, as it will match the RegExp.

As of such, my "Windows compatibility" change (9926325691d750f4cb3a9892fa0e3634e4fd4353, #13) was just plain wrong. If anyone using the according release copies the RegExp and fixes it (by wrapping it in forward slashes or `new RegExp('')`), it will still work, and be even a bit more specific, in that the above file will no longer match, but `projectRoot\node_modules\p-debounce\index.js` will now match on a Windows machine. Oh actually it won't since [I failed to escape the backslash correctly](https://github.com/depoulo/are-you-es5/commit/43730b4150a60278ebc65257ff1070504545d4d1).

The ultimate solution, however, is to put path delimiters (`[\\/]` to work in both Windows and POSIX-compatible environments) around `node_modules` and after the module name (but still inside the negative lookahead). This will remove all theoretical false matches. That is what I'm doing in this pull request, alongside re-adding the surrounding forward slashes to make it a real JavaScript RegExp.




_Personally, I'm doing like this:_

(package.json)
```json
"postinstall": "sh -c \"yarn --silent are-you-es5 check -r . | tail -n 1 > ./non_ES5_node_modules \"",
```

(webpack.config.js)
```js
exclude: forLegacyBrowsers
  ? new RegExp(
      fs
        .readFileSync(path.resolve('./non_ES5_node_modules'), 'utf-8')
        // remove surrounding RegExp delimiter slashes and trailing newline
        .slice(1, -2)
    )
  : /[\\/]node_modules[\\/]/,
```
