### PR TITLE
:bug: Escape namespaced dependencies in Babel exclude regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "are-you-es5",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A package to help you find out which of your `node_modules` aren't ES5 so you can add them to your transpilation steps.",
   "main": "dist/index.js",
   "repository": "https://github.com/obahareth/are-you-es5.git",

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -12,5 +12,5 @@ export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
 }
 
 function escapeNamespacedDependencies(dependencies: string[]): string[] {
-  return dependencies.map((dep) => dep.replace("/", "\\/"))
+  return dependencies.map(dep => dep.replace('/', '\\/'))
 }

--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -1,4 +1,6 @@
 export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
+  dependencies = escapeNamespacedDependencies(dependencies)
+
   // [\\\\/] is a bit confusing but what it's doing is matching either a
   // backslash or forwards slash. Forwards slashes don't need to be
   // escaped inside a character group, and we need to escape the
@@ -7,4 +9,8 @@ export function getBabelLoaderIgnoreRegex(dependencies: string[]) {
   // If you console.log the regex it'll actually turn into:
   // [\\/]
   return `/[\\\\/]node_modules[\\\\/](?!(${dependencies.join('|')})[\\\\/])/`
+}
+
+function escapeNamespacedDependencies(dependencies: string[]): string[] {
+  return dependencies.map((dep) => dep.replace("/", "\\/"))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { ModulesChecker } from './modules-checker'
 import IModuleCheckerConfig from './types/module-checker-config'
 
 program
-  .version('1.3.2')
+  .version('1.3.3')
   .command('check <path>')
   .description(
     'Checks if all node_modules (including monorepos) at <path> are ES5'

--- a/tests/babel-loader-regex-builder.test.ts
+++ b/tests/babel-loader-regex-builder.test.ts
@@ -1,0 +1,17 @@
+import { getBabelLoaderIgnoreRegex } from "../src/babel-loader-regex-builder"
+
+describe('getBabelLoaderIgnoreRegex', () => {
+  it("returns a regex for ignoring dependencies", () => {
+    const dependencies = ["dotenv", "md5-file",]
+    const expectedRegex = "/[\\\\/]node_modules[\\\\/](?!(dotenv|md5-file)[\\\\/])/"
+
+    expect(getBabelLoaderIgnoreRegex(dependencies)).toEqual(expectedRegex)
+  })
+
+  it("handles namespaced dependencies", () => {
+    const dependencies = ["@react-pdf/renderer", "dotenv", "md5-file",]
+    const expectedRegex = "/[\\\\/]node_modules[\\\\/](?!(@react-pdf\\/renderer|dotenv|md5-file)[\\\\/])/"
+
+    expect(getBabelLoaderIgnoreRegex(dependencies)).toEqual(expectedRegex)
+  })
+})

--- a/tests/babel-loader-regex-builder.test.ts
+++ b/tests/babel-loader-regex-builder.test.ts
@@ -1,16 +1,18 @@
-import { getBabelLoaderIgnoreRegex } from "../src/babel-loader-regex-builder"
+import { getBabelLoaderIgnoreRegex } from '../src/babel-loader-regex-builder'
 
 describe('getBabelLoaderIgnoreRegex', () => {
-  it("returns a regex for ignoring dependencies", () => {
-    const dependencies = ["dotenv", "md5-file",]
-    const expectedRegex = "/[\\\\/]node_modules[\\\\/](?!(dotenv|md5-file)[\\\\/])/"
+  it('returns a regex for ignoring dependencies', () => {
+    const dependencies = ['dotenv', 'md5-file']
+    const expectedRegex =
+      '/[\\\\/]node_modules[\\\\/](?!(dotenv|md5-file)[\\\\/])/'
 
     expect(getBabelLoaderIgnoreRegex(dependencies)).toEqual(expectedRegex)
   })
 
-  it("handles namespaced dependencies", () => {
-    const dependencies = ["@react-pdf/renderer", "dotenv", "md5-file",]
-    const expectedRegex = "/[\\\\/]node_modules[\\\\/](?!(@react-pdf\\/renderer|dotenv|md5-file)[\\\\/])/"
+  it('handles namespaced dependencies', () => {
+    const dependencies = ['@react-pdf/renderer', 'dotenv', 'md5-file']
+    const expectedRegex =
+      '/[\\\\/]node_modules[\\\\/](?!(@react-pdf\\/renderer|dotenv|md5-file)[\\\\/])/'
 
     expect(getBabelLoaderIgnoreRegex(dependencies)).toEqual(expectedRegex)
   })


### PR DESCRIPTION
Other changes:
- Add tests for babel-loader `exclude` regex building.

This should fix #20.