### PR TITLE
♻️ Add a Type to ModulesChecker's checkModules Result

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ program
     }
 
     const checker = new ModulesChecker(path, config)
-    const nonEs5Dependencies = checker.checkModules()
+    const nonEs5Dependencies = checker.checkModules().es6Modules
 
     if (cmd.regex) {
       console.log('\n\nBabel-loader exclude regex:')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,11 +38,11 @@ program
     }
 
     const checker = new ModulesChecker(path, config)
-    const nonEs5Dependencies = checker.checkModules().es6Modules
+    const { es6Modules } = checker.checkModules()
 
     if (cmd.regex) {
       console.log('\n\nBabel-loader exclude regex:')
-      console.log(getBabelLoaderIgnoreRegex(nonEs5Dependencies))
+      console.log(getBabelLoaderIgnoreRegex(es6Modules))
     }
   })
 

--- a/src/modules-checker.ts
+++ b/src/modules-checker.ts
@@ -4,6 +4,7 @@ import fs, { lstatSync } from 'fs'
 import path from 'path'
 
 import IModuleCheckerConfig from './types/module-checker-config'
+import IModuleCheckerResult from './types/module-checker-result'
 import { IPackageJSON } from './types/package-json'
 
 export class ModulesChecker {
@@ -22,8 +23,8 @@ export class ModulesChecker {
     this.config = { ...ModulesChecker.defaultConfig, ...config }
   }
 
-  public checkModules(): string[] {
-    return this.parseDeps().es6Modules
+  public checkModules(): IModuleCheckerResult {
+    return this.parseDeps()
   }
 
   public parseDeps(): {

--- a/src/types/module-checker-result.ts
+++ b/src/types/module-checker-result.ts
@@ -1,0 +1,5 @@
+export default interface IModuleCheckerResult {
+  es5Modules: string[]
+  es6Modules: string[]
+  ignored: string[]
+}


### PR DESCRIPTION
- Add `IModuleCheckerResult` with `es5Modules`, `es6Modules`, and `ignored`
- Make `ModulesChecker.checkModules` return an `IModuleCheckerResult` with typeified objects instead of just the ES6 dependencies
- Update tests