### PR TITLE
✨ Non-zero exit code

### DIFF
--- a/src/cli-errors.ts
+++ b/src/cli-errors.ts
@@ -1,0 +1,8 @@
+const CLI_ERRORS = {
+  nonES5DependenciesDetected: {
+    code: 1,
+    message: 'Non-ES5 dependencies detected.'
+  }
+}
+
+export default CLI_ERRORS

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,8 @@
 import program from 'commander'
 
 import { getBabelLoaderIgnoreRegex } from './babel-loader-regex-builder'
+import CLI_ERRORS from './cli-errors'
+import { Logger } from './logger'
 import { ModulesChecker } from './modules-checker'
 import IModuleCheckerConfig from './types/module-checker-config'
 
@@ -38,11 +40,19 @@ program
     }
 
     const checker = new ModulesChecker(path, config)
+    const logger = new Logger(config)
     const nonEs5Dependencies = checker.checkModules()
 
     if (cmd.regex) {
       console.log('\n\nBabel-loader exclude regex:')
       console.log(getBabelLoaderIgnoreRegex(nonEs5Dependencies))
+    }
+
+    if (nonEs5Dependencies.length !== 0) {
+      const error = CLI_ERRORS.nonES5DependenciesDetected
+      logger.log(error.message)
+
+      process.exitCode = error.code
     }
   })
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,13 @@
+import IModuleCheckerConfig from './types/module-checker-config'
+
+export class Logger {
+  constructor(private config: IModuleCheckerConfig) {
+    this.config = config
+  }
+
+  public log(message: string) {
+    if (!this.config.silent) {
+      console.log(message)
+    }
+  }
+}

--- a/src/modules-checker.ts
+++ b/src/modules-checker.ts
@@ -3,6 +3,7 @@ import flatten from 'array-flatten'
 import fs, { lstatSync } from 'fs'
 import path from 'path'
 
+import { Logger } from './logger'
 import IModuleCheckerConfig from './types/module-checker-config'
 import { IPackageJSON } from './types/package-json'
 
@@ -14,12 +15,15 @@ export class ModulesChecker {
     silent: false
   }
 
+  private logger: Logger
+
   constructor(
     readonly dir: string,
     readonly config: IModuleCheckerConfig = ModulesChecker.defaultConfig
   ) {
     this.dir = path.resolve(dir)
     this.config = { ...ModulesChecker.defaultConfig, ...config }
+    this.logger = new Logger(config)
   }
 
   public checkModules(): string[] {
@@ -77,12 +81,12 @@ export class ModulesChecker {
     try {
       acorn.parse(code, acornOpts)
     } catch (err) {
-      this.log(`❌ ${dependencyName} is not ES5`)
+      this.logger.log(`❌ ${dependencyName} is not ES5`)
       return false
     }
 
     if (this.config.logEs5Packages) {
-      this.log(`✅ ${dependencyName} is ES5`)
+      this.logger.log(`✅ ${dependencyName} is ES5`)
     }
 
     return true
@@ -151,11 +155,5 @@ export class ModulesChecker {
     }
 
     throw new Error(`Failed to find node_modules at ${this.dir}`)
-  }
-
-  private log(message: string) {
-    if (!this.config.silent) {
-      console.log(message)
-    }
   }
 }

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,27 @@
+import { Logger } from '../src/logger'
+
+describe('when silent config is present', () => {
+  it('should not log', () => {
+    const spy = jest.spyOn(global.console, 'log')
+    const logger = new Logger({ silent: true })
+    const message = 'Hello, have you received my call?'
+
+    logger.log(message)
+
+    expect(console.log).not.toHaveBeenLastCalledWith(message)
+    spy.mockRestore()
+  })
+})
+
+describe('when silent config is not present', () => {
+  it('should log', () => {
+    const spy = jest.spyOn(global.console, 'log')
+    const logger = new Logger({ silent: false })
+    const message = 'Hello, have you received my call?'
+
+    logger.log(message)
+
+    expect(console.log).toHaveBeenLastCalledWith(message)
+    spy.mockRestore()
+  })
+})

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,20 +1,7 @@
 import { Logger } from '../src/logger'
 
-describe('when silent config is present', () => {
-  it('should not log', () => {
-    const spy = jest.spyOn(global.console, 'log')
-    const logger = new Logger({ silent: true })
-    const message = 'Hello, have you received my call?'
-
-    logger.log(message)
-
-    expect(console.log).not.toHaveBeenLastCalledWith(message)
-    spy.mockRestore()
-  })
-})
-
-describe('when silent config is not present', () => {
-  it('should log', () => {
+describe('Logger', () => {
+  it('should log by default', () => {
     const spy = jest.spyOn(global.console, 'log')
     const logger = new Logger({ silent: false })
     const message = 'Hello, have you received my call?'
@@ -22,6 +9,17 @@ describe('when silent config is not present', () => {
     logger.log(message)
 
     expect(console.log).toHaveBeenLastCalledWith(message)
+    spy.mockRestore()
+  })
+
+  it('should do nothing when configured to be silent', () => {
+    const spy = jest.spyOn(global.console, 'log')
+    const logger = new Logger({ silent: true })
+    const message = 'Hello, have you received my call?'
+
+    logger.log(message)
+
+    expect(console.log).not.toHaveBeenLastCalledWith(message)
     spy.mockRestore()
   })
 })

--- a/tests/modules-checker.test.ts
+++ b/tests/modules-checker.test.ts
@@ -184,24 +184,3 @@ describe('checkModules', () => {
     expect(mockIsScriptEs5).toHaveBeenCalledTimes(subpackageDependencies.length)
   })
 })
-
-describe('silent', () => {
-  it('should not log', () => {
-    // Spy on console.log
-    const spy = jest.spyOn(global.console, 'log')
-
-    const modulesChecker = new ModulesChecker(
-      `${__dirname}/support/fixtures/root`,
-      { checkAllNodeModules: true, logEs5Packages: true, silent: true }
-    )
-
-    allDependenciesWithEntryPaths.forEach(dependency => {
-      modulesChecker.isScriptEs5(dependency.path, dependency.name)
-      expect(console.log).not.toHaveBeenLastCalledWith(
-        dependency.expectedOutput
-      )
-    })
-
-    spy.mockRestore()
-  })
-})


### PR DESCRIPTION
This will exit with a non-zero code when ES6+ dependencies are detected.

This should fix #29.

Other Changes:

- I snuck in a small refactor that moved logging into its own class (`Logger`)