### PR TITLE
fix: replace hard coded separator to path.sep

### DIFF
--- a/src/modules-checker.ts
+++ b/src/modules-checker.ts
@@ -125,7 +125,7 @@ export class ModulesChecker {
       }
 
       const getLeafFolderName = (fullPath: string): string => {
-        const needle = 'node_modules/'
+        const needle = 'node_modules' + path.sep
         const indexOfLastSlash = fullPath.lastIndexOf(needle)
         return fullPath.substr(indexOfLastSlash + needle.length)
       }


### PR DESCRIPTION
In Windows, `getLeafFolderName()` will return the strange path due to the difference of path separator. I've replaced hard coded separator `/` into [`path.sep`](https://nodejs.org/api/path.html#path_path_sep).

closes #49.