### PR TITLE
fix buildExcludeRegexp

### DIFF
--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -34,6 +34,6 @@ export function buildIncludeRegexp(dependencies: string[]) {
  */
 export function buildExcludeRegexp(dependencies: string[]) {
   return new RegExp(
-    `${nodeModules}?!(${dependencies.map(escape).join('|')})${crossEnvSlash}`
+    `${nodeModules}(?!(${dependencies.map(escape).join('|')})${crossEnvSlash})`
   )
 }


### PR DESCRIPTION
the old regex is not working in webpack/babel-loader/exclude