### PR TITLE
Feature/vueconfig

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,10 @@ program
     'Stops all filtering on babel-loader exclude regex (does not hide anything) '
   )
   .option(
+    '-l, --list',
+    "Return a JSON.stringify'd array of modules for use with vue.config.js in transpileDependencies"
+  )
+  .option(
     '-r, --regex',
     'Get babel-loader exclude regex to ignore all node_modules except non-ES5 ones, by default does not show any babel or webpack modules, use with --no-regex-filtering if you want to see everything'
   )
@@ -46,6 +50,10 @@ program
     if (cmd.regex) {
       console.log('\n\nBabel-loader exclude regex:')
       console.log(getBabelLoaderIgnoreRegex(es6Modules))
+    }
+    if (cmd.list) {
+      console.log('\n\nArray:');
+      console.log(JSON.stringify(es6Modules));
     }
 
     if (es6Modules.length !== 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,11 +48,11 @@ program
     const { es6Modules } = checker.checkModules()
 
     if (cmd.regex) {
-      console.log('\n\nBabel-loader exclude regex:')
+      console.warn('\n\nBabel-loader exclude regex:')
       console.log(getBabelLoaderIgnoreRegex(es6Modules))
     }
     if (cmd.list) {
-      console.log('\n\nArray:');
+      console.warn('\n\nArray:');
       console.log(JSON.stringify(es6Modules));
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,10 @@ export class Logger {
 
   public log(message: string) {
     if (!this.config.silent) {
-      console.log(message)
+      // Use console.warn so the messages go to stderr instead of stdout;
+      // that makes it easier to use this from a shell script where you can
+      // redirect stdout and everything is useful.
+      console.warn(message)
     }
   }
 }


### PR DESCRIPTION
I wanted to use this with `vue.config.js` which wraps webpack; it has an option `transpileDependencies` which is just an array of node_modules which should be processed with babel-loader, so I added an option to `are-you-es5` to output a simple array of module names which can be used with it.

While I was in there I made it send log messages to `stderr`; that way you can do e.g.:

    npx are-you-es5 check -r /path/to/project > regex.txt

and it will show you the log messages, but send the usable regular expression to the file.