### PR TITLE
Fixes script for libraries that doesn't have dependencies

### DIFF
--- a/src/modules-checker.ts
+++ b/src/modules-checker.ts
@@ -107,7 +107,7 @@ export class ModulesChecker {
       throw new Error(`Failed to load package.json in ${this.dir}`)
     }
 
-    return Object.keys(packageJson.dependencies)
+    return Object.keys(packageJson.dependencies || {})
   }
 
   private getAllNodeModules(): string[] | null {


### PR DESCRIPTION
dependencies attribute in package.json file isn't required and it could not exist in some cases. In my case, I use lerna and yarn workspaces to manage my monorepo, and some libraries doesn't have dependencies and this causes the script to fail