### PR TITLE
Fix buildExcludeRegexp to use a negative lookahead

### DIFF
--- a/src/babel-loader-regex-builder.ts
+++ b/src/babel-loader-regex-builder.ts
@@ -34,6 +34,6 @@ export function buildIncludeRegexp(dependencies: string[]) {
  */
 export function buildExcludeRegexp(dependencies: string[]) {
   return new RegExp(
-    `${nodeModules}?!(${dependencies.map(escape).join('|')})${crossEnvSlash}`
+    `${nodeModules}(?!(${dependencies.map(escape).join('|')})${crossEnvSlash})`
   )
 }


### PR DESCRIPTION
The output from buildExcludeRegexp would fail to work, as the JavaScript regex negative lookahead operator is X(?!Y). This patch adds the missing parentheses.